### PR TITLE
Enable saving paragraphs via :w

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Use your favorite plugin manager to install this plugin. For example, using lazy
 - List notebooks: `:Zeppelin` - This will open a buffer showing all available notebooks. Press `<CR>` on a notebook to open it.
 - Filter notebooks: press `f` in the notebooks buffer and type the notebook name to filter notebooks.
 - Navigating paragraphs: use `<leader><Right>` and `<leader><Left>` to navigate between paragraphs.
-- Saving changes: use `<leader>w` to save changes in a paragraph.
+- Saving changes: use `:w` to save changes in a paragraph.
 - Running code: use `<leader>r` to run code in a paragraph.
 
 ## License

--- a/lua/zeppelin/notebook.lua
+++ b/lua/zeppelin/notebook.lua
@@ -267,6 +267,7 @@ function M.open_notebook_slideshow(notebook_json)
     vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
     vim.api.nvim_buf_set_option(buf, "modifiable", true)
     vim.api.nvim_buf_set_option(buf, "readonly", false)
+    vim.api.nvim_buf_set_option(buf, "buftype", "acwrite")
 
     vim.api.nvim_buf_set_var(buf, "zeppelin_paragraphs", paragraphs)
     vim.api.nvim_buf_set_var(buf, "zeppelin_paragraph_index", 1)
@@ -297,13 +298,13 @@ function M.open_notebook_slideshow(notebook_json)
         { nowait = true, noremap = true, silent = true }
     )
 
-    vim.api.nvim_buf_set_keymap(
-        buf,
-        "n",
-        "<leader>w",
-        "<cmd>lua require('zeppelin.notebook').save_current_paragraph()<CR>",
-        { nowait = true, noremap = true, silent = true }
-    )
+
+    vim.api.nvim_create_autocmd("BufWriteCmd", {
+        buffer = buf,
+        callback = function()
+            require('zeppelin.notebook').save_current_paragraph()
+        end,
+    })
 
     vim.api.nvim_set_current_buf(buf)
 end


### PR DESCRIPTION
## Summary
- map `:w` to saving paragraphs
- update README to mention `:w` for saving

## Testing
- `luacheck --version` *(fails: command not found)*
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684825f1dae0832ca1587deec53b9d42