### PR TITLE
Fix first line missing when saving paragraph

### DIFF
--- a/lua/zeppelin/notebook.lua
+++ b/lua/zeppelin/notebook.lua
@@ -127,7 +127,9 @@ function M.save_current_paragraph()
     local saveUrl = string.format("%s/api/notebook/%s/paragraph/%s", config.options.ZEPPELIN_URL, notebookId, paragraphId)
 
     -- Get updated code from buffer
-    local new_code = table.concat(vim.api.nvim_buf_get_lines(bufnr, 1, -1, false), "\n")
+    -- Grab all lines from the buffer. Index 0 is the first line in Neovim,
+    -- so starting from 1 would drop the first line of code.
+    local new_code = table.concat(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), "\n")
 
     local payload = vim.fn.json_encode({ text = new_code })
 


### PR DESCRIPTION
## Summary
- capture all buffer lines when saving paragraphs

## Testing
- `luac -p lua/zeppelin/notebook.lua`
- `find lua -name '*.lua' -print | xargs -I{} luac -p {}`

------
https://chatgpt.com/codex/tasks/task_e_684831033aec832c91566ce8b0ee2561